### PR TITLE
Add switch command feature

### DIFF
--- a/src/main/java/io/github/darkkronicle/advancedchathud/config/ChatTab.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/config/ChatTab.java
@@ -104,6 +104,12 @@ public class ChatTab {
                     new ConfigBoolean(
                             translate("showunread"), false, translate("info.showunread")));
 
+    private SaveableConfig<ConfigString> switchCommand =
+            SaveableConfig.fromConfig(
+                    "switchCommand",
+                    new ConfigString(
+                            translate("switchcommand"), "", translate("info.switchcommand")));
+
     private final ImmutableList<SaveableConfig<?>> options =
             ImmutableList.of(
                     name,
@@ -114,7 +120,8 @@ public class ChatTab {
                     mainColor,
                     borderColor,
                     innerColor,
-                    showUnread);
+                    showUnread,
+                    switchCommand);
 
     /** Options that the main tab can use */
     private final ImmutableList<SaveableConfig<?>> mainEditableOptions =
@@ -126,7 +133,8 @@ public class ChatTab {
                     mainColor,
                     borderColor,
                     innerColor,
-                    showUnread);
+                    showUnread,
+                    switchCommand);
 
     public FindType getFind() {
         return matches.get(0).getFindType();

--- a/src/main/java/io/github/darkkronicle/advancedchathud/gui/WindowManager.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/gui/WindowManager.java
@@ -183,6 +183,11 @@ public class WindowManager implements IRenderer, ResolutionEventHandler {
         windows.removeIf(w -> w == window);
         windows.add(0, window);
 
+        // Execute switch command if it's a CustomChatTab
+        if (window.getTab() instanceof CustomChatTab customTab) {
+            customTab.executeSwitchCommand();
+        }
+
         if (!HudConfigStorage.General.CHANGE_START_MESSAGE.config.getBooleanValue() || !(client.currentScreen instanceof AdvancedChatScreen screen)) {
             return;
         }

--- a/src/main/java/io/github/darkkronicle/advancedchathud/tabs/CustomChatTab.java
+++ b/src/main/java/io/github/darkkronicle/advancedchathud/tabs/CustomChatTab.java
@@ -20,6 +20,7 @@ import io.github.darkkronicle.advancedchathud.config.ChatTab;
 import io.github.darkkronicle.advancedchathud.config.Match;
 import lombok.Getter;
 import lombok.Setter;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 
 import java.util.ArrayList;
@@ -37,6 +38,10 @@ public class CustomChatTab extends AbstractChatTab {
     @Getter
     @Setter
     private String startingMessage;
+
+    @Getter
+    @Setter
+    private String switchCommand;
 
     @Getter
     @Setter
@@ -59,6 +64,7 @@ public class CustomChatTab extends AbstractChatTab {
         this.matches = new ArrayList<>(tab.getMatches());
         this.forward = tab.getForward().config.getBooleanValue();
         this.startingMessage = tab.getStartingMessage().config.getStringValue();
+        this.switchCommand = tab.getSwitchCommand().config.getStringValue();
         setDefaultFunction();
     }
 
@@ -104,5 +110,18 @@ public class CustomChatTab extends AbstractChatTab {
             }
         }, new LiteralNode(search)));
         return result.getContent().getBoolean();
+    }
+
+    /**
+     * Executes the switch command if one is configured.
+     */
+    public void executeSwitchCommand() {
+        if (switchCommand != null && !switchCommand.trim().isEmpty()) {
+            MinecraftClient client = MinecraftClient.getInstance();
+            if (client.player != null) {
+                // Execute the command as if the player typed it
+                client.player.networkHandler.sendChatCommand(switchCommand.trim());
+            }
+        }
     }
 }

--- a/src/main/resources/assets/advancedchathud/lang/en_us.json
+++ b/src/main/resources/assets/advancedchathud/lang/en_us.json
@@ -121,6 +121,8 @@
   "advancedchathud.config.tab.info.innercolor": "The color of the §6background§r of the §bchat tab",
   "advancedchathud.config.tab.showunread": "Show Unread Messages",
   "advancedchathud.config.tab.info.showunread": "Whether or not the number of §6unread messages§r are displayed for the §bchat tab§r",
+  "advancedchathud.config.tab.switchcommand": "Switch Command",
+  "advancedchathud.config.tab.info.switchcommand": "A command that will be executed when switching to this tab. Leave empty to disable.",
 
   "advancedchathud.windowconfig.x": "Window X",
   "advancedchathud.windowconfig.info.x": "The X value for the window",


### PR DESCRIPTION
# Add Switch Command Feature for Chat Tabs

## Summary
This PR adds the ability to execute a configured command automatically when switching to a chat tab. This feature enhances the existing chat tab functionality by allowing users to trigger commands (like `/say`, `/me`, or any other Minecraft command) whenever they switch to a specific tab.

## How It Works
1. Users can configure a "Switch Command" in the chat tab settings
2. When switching to a tab that has a command configured, the command executes automatically
3. Commands are executed using `MinecraftClient.player.networkHandler.sendChatCommand()`
4. Only works with `CustomChatTab` instances (not the main tab)
5. **Note**: Do not include the `/` prefix when entering commands in the configuration - the mod will add it automatically

## Use Cases
- **Multi-Channel Servers**: Automatically switch to the appropriate chat channel when clicking on a tab (e.g., `/channel general`, `/channel trade`, `/channel pvp`)
- **Server Communication**: Automatically send status messages when switching to specific tabs
- **Roleplay**: Execute `/me` commands to indicate character actions
- **Automation**: Trigger server-side scripts or plugins when accessing certain chat channels
- **Notifications**: Send alerts or announcements when switching to important tabs

## Example Usage
```
Tab Name: "General Chat"
Switch Command: "channel general"

Tab Name: "Admin Chat"
Switch Command: "say Switching to admin mode"
```

Every time a user switches to the "General Chat" tab, the command `/channel general` will be executed automatically, switching them to that channel on the server.

## Technical Details
- Commands are executed safely with null checks for player availability
- Empty or whitespace-only commands are ignored
- Integration follows existing code patterns and architecture
- Fully compatible with existing configuration save/load system
- Build tested successfully with no compilation errors

## Backward Compatibility
This feature is fully backward compatible. Existing tabs without a switch command configured will continue to work exactly as before.

---

*Note: This PR message was written by AI as it's currently 3 AM and I'm too lazy to type one up myself 😅*
